### PR TITLE
Thread interruption exceptions are caught now and don't go to the console

### DIFF
--- a/src/subscript/subscript/akka/SubScriptActorRunner.scala
+++ b/src/subscript/subscript/akka/SubScriptActorRunner.scala
@@ -50,7 +50,8 @@ object SSARunnerV1Scheduler extends SubScriptActorRunner {
   def doScriptSteps_loop: Unit = {
     doScriptSteps
     if (executor.hasActiveProcesses) {
-      system.scheduler.scheduleOnce(scheduledTaskDelay)(doScriptSteps_loop)
+      try system.scheduler.scheduleOnce(scheduledTaskDelay)(doScriptSteps_loop)
+      catch {case _: IllegalStateException =>}  // Ignore certain things...
     }
   }
 

--- a/src/subscript/subscript/vm/CallGraphNode.scala
+++ b/src/subscript/subscript/vm/CallGraphNode.scala
@@ -244,7 +244,7 @@ abstract class N_atomic_action  extends CallGraphLeafNode with DoCodeHolder[Unit
 
 case class N_code_normal     (template: T_code_normal  ) extends N_atomic_action {type T = T_code_normal  ; def doCode = template.code.apply.apply(this)}
 case class N_code_tiny       (template: T_code_tiny    ) extends N_atomic_action {type T = T_code_tiny    ; def doCode = template.code.apply.apply(this)}
-case class N_code_threaded   (template: T_code_threaded) extends N_atomic_action {type T = T_code_threaded; def doCode = template.code.apply.apply(this)}
+case class N_code_threaded   (template: T_code_threaded) extends N_atomic_action {type T = T_code_threaded; def doCode = try template.code.apply.apply(this) catch {case _: InterruptedException =>}}  // Don't pollute the output
 case class N_code_unsure     (template: T_code_unsure  ) extends N_atomic_action {type T = T_code_unsure  ; def doCode = template.code.apply.apply(this)
   private var _result = UnsureExecutionResult.Success; // TBD: clean this all up; hasSuccess+result is too much
   def result = _result

--- a/src/subscript/subscript/vm/CodeExecutor.scala
+++ b/src/subscript/subscript/vm/CodeExecutor.scala
@@ -147,7 +147,7 @@ trait CodeExecutorAdapter[CE<:CodeExecutorTrait] extends CodeExecutorTrait {
   }
 }
 class ThreadedCodeFragmentExecutor(n: N_code_threaded, scriptExecutor: ScriptExecutor) extends NormalCodeFragmentExecutor(n, scriptExecutor)  {
-  override def interruptAA: Unit = if (myThread!=null) myThread.interrupt
+  override def interruptAA: Unit = if (myThread!=null) try myThread.interrupt catch {case _: InterruptedException =>}  // Don't pollute the outout
   regardStartAndEndAsSeparateAtomicActions = true
   var myThread: Thread = null
   


### PR DESCRIPTION
These exceptions are expected and not dangerous. With them logged, system spends additional resources for console I/O and pollutes the console. So now the thread interruption exceptions are caught in appropriate places.
