### PR TITLE
Debugger separated into a PureScalaDebugger and SubScriptDebugger

### DIFF
--- a/src/subscript-swing/src/swing/PureScalaDebugger.scala
+++ b/src/subscript-swing/src/swing/PureScalaDebugger.scala
@@ -1,0 +1,59 @@
+package subscript.swing
+
+import java.util.concurrent.Executors
+
+import scala.swing._
+import scala.swing.event._
+
+import scala.concurrent._
+import scala.concurrent.duration._
+
+object PureScalaDebugger extends PureScalaDebuggerApp
+
+class PureScalaDebuggerApp extends SimpleSwingApplication with GraphicalDebugger {
+  implicit val executionContext = ExecutionContext fromExecutorService Executors.newCachedThreadPool()
+
+  def live = {
+
+    def again: Unit = Future {awaitMessageBeingHandled(true)}.flatMap {_ =>
+      if (shouldStep) {
+        Swing.onEDTWait(updateDisplay)
+        Future firstCompletedOf Seq(stepCommand, autoStepCommand)
+      } else Future.successful(())
+    }.onSuccess {case _ =>
+      messageBeingHandled(false)
+      again
+    }
+
+    again
+    waitForExit
+  }
+
+  def stepCommand: Future[Unit] = {
+    val promise = Promise[Unit]()
+    new Reactor {
+      stepButton.enabled = true
+      listenTo(stepButton)
+      reactions += {case _: ButtonClicked => promise.success(()); deafTo(stepButton)}
+    }
+    promise.future
+  }
+
+  def autoStepCommand: Future[Unit] = {
+    lazy val never = Promise[Unit]().future
+    if (autoCheckBox.selected) Future {waitForStepTimeout} else never
+  }
+
+  def waitForExit = {
+    val liveAnchor = Promise[Unit]()
+    new Reactor {
+      exitButton.enabled = true
+      listenTo(exitButton)
+      reactions += {case _: ButtonClicked => liveAnchor.success(())}
+    }
+    Await.ready(liveAnchor.future, Duration.Inf)
+  }
+
+  override def main(args: Array[String]) = super.main(args)
+
+}

--- a/src/subscript-swing/src/swing/Scripts.scala
+++ b/src/subscript-swing/src/swing/Scripts.scala
@@ -47,7 +47,7 @@ abstract class SimpleSubscriptApplication extends SimpleSwingApplication{
     new Thread{override def run={live;quit}}.start()
   }
   def _live: Script[Any]
-  def  live: ScriptExecutor[Any]
+  def  live: Unit
 }
 
 /*

--- a/src/subscript-swing/src/swing/SubScriptDebugger.scala
+++ b/src/subscript-swing/src/swing/SubScriptDebugger.scala
@@ -1,0 +1,31 @@
+package subscript.swing
+
+import subscript.swing.Scripts._
+import subscript.DSL._
+
+object SubScriptDebugger extends SubScriptDebuggerApp
+
+class SubScriptDebuggerApp extends SimpleSubscriptApplication with GraphicalDebugger {
+
+  override def live: Unit = try _execute(_live, debugger=null, myScriptExecutor)
+                            catch {case t:Throwable => t.printStackTrace; throw t}
+
+  override def main(args: Array[String]) = super.main(args)
+
+  def script..
+     live       = (
+                    {*awaitMessageBeingHandled(true)*}
+                    ( if shouldStep then (
+                        @{gui(there)}: {!updateDisplay!}
+                        stepCommand || if autoCheckBox.selected then {*waitForStepTimeout*}
+                    ) )
+                    {messageBeingHandled(false)}
+                    ... // TBD: parsing goes wrong without this comment; lineStartOffset was incremented unexpectedly
+                  )
+                  || exitDebugger
+
+   stepCommand  = stepButton
+   exitCommand  = exitButton
+   exitDebugger = exitCommand @{gui(there)}:{exitConfirmed=confirmExit} while(!exitConfirmed)
+
+}


### PR DESCRIPTION
In order to make Gradle work with it, go to the build.gradle of the project you want to debug, locate the `task(debug, dependsOn: 'classes', type: JavaExec)` line there, locate its property `main`. In order to debug with pure scala debugger, set `main = 'subscript.swing.PureScalaDebugger'`. In order to debug with SubScript debugger, set `main = 'subscript.swing.SubScriptDebugger'`.
